### PR TITLE
Add proper JAX implementation (using JAX operators)

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ def benchmark_gradient_descent(X, D, lr, niter):
 def benchmark_gradient_descent_JAX(X, D, lr, niter):
     secs = timeit(lambda: gradient_descent_JAX(X, D, learning_rate=lr, num_iterations=niter), number=10) / 10
     print(f"Average time JAX: {secs}")
-    
+
 def benchmark_gradient_descent_cpp(X, D, lr, niter):
     secs = timeit(lambda: gradient_descent_cpp(X, D, learning_rate=lr, num_iterations=niter), number=10) / 10
     print(f"Average time C++ binding: {secs}")

--- a/main.py
+++ b/main.py
@@ -93,9 +93,8 @@ def benchmarks(D, dim, lr, niter, plots=True):
         P_native, L_native = gradient_descent_native_cache(X_native.copy(), D_native, learning_rate=lr, num_iterations=niter)
         plot_gradient_descent(P_native, L_native, title="Gradient Descent in native python")
 
-        # TODO
-        # P_JAX, L_JAX = gradient_descent_cache_JAX(X.copy(), D, learning_rate=lr, num_iterations=niter)
-        # plot_gradient_descent(P_JAX, L_JAX, title="Gradient Descent in JAX")
+        P_JAX, L_JAX = gradient_descent_cache_JAX(X.copy(), D, learning_rate=lr, num_iterations=niter)
+        plot_gradient_descent(P_JAX.tolist(), L_JAX.tolist(), title="Gradient Descent in JAX")
         
         # (cache function not implemented: Can only plot final value)
         plot_gradient_descent(p_cpp, -1, title="Gradient Descent in C++")

--- a/main.py
+++ b/main.py
@@ -43,20 +43,21 @@ def generate_distance_matrix(points):
     return distance_matrix
 
 
+NUM_ITERS = 10
 def benchmark_gradient_descent_native(X_native, D_native, lr, niter):
-    secs = timeit(lambda: gradient_descent_native(X_native, D_native, learning_rate=lr, num_iterations=niter), number=2) / 2
+    secs = timeit(lambda: gradient_descent_native(X_native, D_native, learning_rate=lr, num_iterations=niter), number=NUM_ITERS) / NUM_ITERS
     print(f"Average time python native: {secs}")
 
 def benchmark_gradient_descent(X, D, lr, niter):
-    secs = timeit(lambda: gradient_descent(X, D, learning_rate=lr, num_iterations=niter), number=2) / 2
+    secs = timeit(lambda: gradient_descent(X, D, learning_rate=lr, num_iterations=niter), number=NUM_ITERS) / NUM_ITERS
     print(f"Average time python numpy: {secs}")
 
 def benchmark_gradient_descent_JAX(X, D, lr, niter):
-    secs = timeit(lambda: gradient_descent_JAX(X, D, learning_rate=lr, num_iterations=niter), number=10) / 10
+    secs = timeit(lambda: gradient_descent_JAX(X, D, learning_rate=lr, num_iterations=niter), number=NUM_ITERS) / NUM_ITERS
     print(f"Average time JAX: {secs}")
 
 def benchmark_gradient_descent_cpp(X, D, lr, niter):
-    secs = timeit(lambda: gradient_descent_cpp(X, D, learning_rate=lr, num_iterations=niter), number=10) / 10
+    secs = timeit(lambda: gradient_descent_cpp(X, D, learning_rate=lr, num_iterations=niter), number=NUM_ITERS) / NUM_ITERS
     print(f"Average time C++ binding: {secs}")
 
 

--- a/python/gradient_descent_JAX.py
+++ b/python/gradient_descent_JAX.py
@@ -38,19 +38,12 @@ def compute_gradient(X, D):
 
 def iter1(carry, row1):
     X, D = carry
-    iterations = jnp.arange(X.shape[0])
-    (X, D, row1), grad = jax.lax.scan(calc_single_grad, (X, D, row1), iterations)
-    grad = jnp.sum(grad, axis=0)    
-    return (X, D), grad
-
-def calc_single_grad(carry, row2):
-    X, D, row1 = carry
-    
-    difference = X[row1] - X[row2]
-    squared_distance = difference @ difference.T
-    grad = 4 * (squared_distance - D[row1, row2]**2) * difference
-    return (X, D, row1), grad
-
+    diff = X[row1] - X
+    diff_squared = diff ** 2
+    squared_distance = jnp.sum(diff_squared, axis=diff_squared.ndim - 1)
+    squared_distance_diff = 4 * (squared_distance - (D[row1] ** 2).T)
+    squared_distance_diff_reshaped = jnp.reshape(squared_distance_diff, (squared_distance_diff.shape[0], 1))
+    return (X, D), jnp.sum(squared_distance_diff_reshaped * diff, axis=0)
 
 # ----- Jax cache method for plotting -----
 def gradient_descent_cache_JAX(X, D, learning_rate=0.001, num_iterations=1000):

--- a/python/gradient_descent_JAX.py
+++ b/python/gradient_descent_JAX.py
@@ -51,17 +51,13 @@ def gradient_descent_cache_JAX(X, D, learning_rate=0.001, num_iterations=1000):
     X = jnp.array(X)
     
     iterations = jnp.arange(num_iterations)
-    (X, learning_rate, D), (positions_over_time, loss_over_time) = jax.lax.scan(grad_step_with_time_evolution, (X, learning_rate, D), iterations)
-
-    #positions_over_time.append(X.copy())
-    #loss_over_time.append(loss(X, D))
+    _, (positions_over_time, loss_over_time) = jax.lax.scan(grad_step_with_time_evolution, (X, learning_rate, D), iterations)
 
     return positions_over_time, loss_over_time
 
-
-def grad_step_with_time_evolution(carry, x):
+def grad_step_with_time_evolution(carry, _):
     X, learning_rate, D = carry
     loss_val = loss(X, D)
     grad = compute_gradient(X, D)
     X -= learning_rate * grad
-    return (X, learning_rate, D), (X,loss_val)
+    return (X, learning_rate, D), (X, loss_val)


### PR DESCRIPTION
The current JAX implementation was written using multiple `jax.lax.scan` operators and seemed to be slow. Add a better implementation with one less `jax.lax.scan` operator and other `jax.numpy` operators.

This new implementations runs faster than the current implementation as benchmarked on a machine with AMD EPYC 9554 (64-cores).

<img width="1102" alt="image" src="https://github.com/StijnWoestenborghs/gradi-mojo/assets/84900961/5f14776f-3934-4b7b-bb3c-227552c67e0b">


